### PR TITLE
Configure project for Sonatype deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,21 +7,27 @@
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners
 
 name: CI
-on: push
+on:
+  release:
+    types: [published]
+  push:
 
 jobs:
   build:
     runs-on: ubuntu-16.04
     env:
+      SONATYPE_NEXUS_USERNAME: ${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
+      SONATYPE_NEXUS_PASSWORD: ${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
       GRADLE_ARGS: >-
         --stacktrace
         --no-daemon
+        --no-parallel
         --max-workers 2
         -Pkotlin.incremental=false
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2-beta
+        uses: actions/checkout@v2
 
       - name: Set up JDK
         uses: actions/setup-java@v1
@@ -45,3 +51,26 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+
+      - name: Snapshot
+        if: startsWith(github.ref, 'refs/heads/') && endsWith(github.ref, '-SNAPSHOT')
+        run: >-
+          ./gradlew
+          $GRADLE_ARGS
+          uploadArchives
+          -PVERSION_NAME="${GITHUB_REF/refs\/heads\//}"
+
+      - name: Keyring
+        if: startsWith(github.ref, 'refs/tags/')
+        run: echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 --decode > ~/secring.gpg
+
+      - name: Publish
+        if: startsWith(github.ref, 'refs/tags/')
+        run: >-
+          ./gradlew
+          $GRADLE_ARGS
+          uploadArchives
+          -PVERSION_NAME=${GITHUB_REF/refs\/tags\//}
+          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}"
+          -Psigning.password="${{ secrets.SIGNING_PASSWORD }}"
+          -Psigning.secretKeyRingFile="$HOME/secring.gpg"

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /local.properties
 /.idea/*
 .DS_Store
-/build
+build/
 /captures
 .externalNativeBuild
 .cxx

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![codecov](https://codecov.io/gh/JuulLabs-OSS/stropping/branch/master/graph/badge.svg)](https://codecov.io/gh/JuulLabs-OSS/stropping)
+[![codecov](https://codecov.io/gh/JuulLabs/stropping/branch/master/graph/badge.svg)](https://codecov.io/gh/JuulLabs/stropping)
 
 # Stropping
 
@@ -55,12 +55,14 @@ class MyApplication {
 
 ## Gradle
 
-In your project-level `build.gradle`, you will need to make sure that jitpack is enabled as a repository:
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.juul.stropping/stropping/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.juul.stropping/stropping)
+
+In your project-level `build.gradle`:
 
 ```gradle
 allprojects {
     repositories {
-        maven { url "https://jitpack.io" }
+        jcenter() // or mavenCentral()
     }
 }
 ```
@@ -69,7 +71,7 @@ Then, in your app `build.gradle`:
 
 ```gradle
 dependencies {
-    androidTestImplementation "com.github.juullabs-oss:stropping:$version"
+    androidTestImplementation "com.juul.stropping:stropping:$version"
 }
 ```
 
@@ -87,7 +89,7 @@ dependencies {
 # License
 
 ```
-Copyright 2019 JUUL Labs, Inc.
+Copyright 2020 JUUL Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,10 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
-    ext.metadata = [
-            // groupId: 'com.juul.stropping',
-            groupId: 'com.github.juullabs-oss',
-    ]
     ext.versions = [
             buildTools: '29.0.2',
             dagger    : '2.27',
             jvmTarget : '1.8',
             kodein    : '6.3.3',
-            kotlin    : '1.3.41',
+            kotlin    : '1.3.72',
             mockk     : '1.9.2',
             sdk       : [
                     compile: 29,
@@ -52,7 +46,7 @@ buildscript {
             ],
             kotlin   : [
                     reflect: "org.jetbrains.kotlin:kotlin-reflect:1.3.0",
-                    stdlib : "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$versions.kotlin",
+                    stdlib : "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlin",
                     test   : [
                             junit: "org.jetbrains.kotlin:kotlin-test-junit:$versions.kotlin",
                     ],
@@ -72,6 +66,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.10.0"
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.11.1'
     }
 }
 
@@ -84,20 +79,6 @@ allprojects {
 
 task clean(type: Delete) {
     delete rootProject.buildDir
-}
-
-/** Helper function for maven publishing. */
-static def addDependency(node, scope, dependency) {
-    if (dependency.group == null) return
-    if (dependency.name == null) return
-    if (dependency.version == null) return
-    if (dependency.name == 'unspecified') return
-    if (dependency.version == 'unspecified') return
-    def dependencyNode = node.appendNode('dependency')
-    dependencyNode.appendNode('groupId', dependency.group)
-    dependencyNode.appendNode('artifactId', dependency.name)
-    dependencyNode.appendNode('version', dependency.version)
-    dependencyNode.appendNode('scope', scope)
 }
 
 apply plugin: 'org.jetbrains.dokka'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -34,7 +34,6 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation deps.androidx.appcompat
     implementation deps.androidx.core
     implementation deps.androidx.constraintlayout

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,22 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+GROUP=com.juul.stropping
+VERSION_NAME=unspecified
+
+POM_NAME=Stropping
+POM_DESCRIPTION=Stropping performs reflection on Dagger to make instrumented testing easier.
+
+POM_URL=https://github.com/JuulLabs/stropping
+POM_SCM_URL=https://github.com/JuulLabs/stropping
+POM_SCM_CONNECTION=scm:git:git://github.com/JuulLabs/stropping.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/JuulLabs/stropping.git
+
+POM_LICENSE_NAME=The Apache Software License, Version 2.0
+POM_LICENSE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENSE_DIST=repo
+
+POM_DEVELOPER_ID=cedrickcooke
+POM_DEVELOPER_NAME=Cedrick Cooke
+POM_DEVELOPER_URL=https://github.com/cedrickcooke

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip

--- a/stropping/build.gradle
+++ b/stropping/build.gradle
@@ -1,11 +1,9 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'maven-publish'
+apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka'
 apply from: rootProject.file('gradle/jacoco-android.gradle')
-
-group=metadata.groupId
 
 android {
     compileSdkVersion versions.sdk.compile
@@ -36,29 +34,6 @@ android {
     }
 }
 
-project.afterEvaluate {
-    publishing {
-        publications {
-            library(MavenPublication) {
-                setGroupId metadata.groupId
-                setArtifactId 'stropping'
-                version android.defaultConfig.versionName
-                artifact bundleReleaseAar
-
-                pom.withXml {
-                    def dependencies = asNode().appendNode('dependencies')
-                    configurations.implementation.allDependencies.each { dependency ->
-                        addDependency(dependencies, 'runtime', dependency)
-                    }
-                    configurations.api.allDependencies.each { dependency ->
-                        addDependency(dependencies, 'compile', dependency)
-                    }
-                }
-            }
-        }
-    }
-}
-
 dokka {
     configuration {
         jdkVersion = 8
@@ -75,7 +50,6 @@ dokka {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation deps.androidx.appcompat
     implementation deps.androidx.core
     implementation deps.androidx.test.ext.junit

--- a/stropping/gradle.properties
+++ b/stropping/gradle.properties
@@ -1,0 +1,1 @@
+POM_ARTIFACT_ID=stropping

--- a/stropping/package.md
+++ b/stropping/package.md
@@ -1,3 +1,3 @@
 # Package com.juul.stropping.kodein
 
-`androidTestImplementation "com.github.juullabs-oss.stropping:kodein:$version"`
+`androidTestImplementation "com.juul.stropping:kodein:$version"`


### PR DESCRIPTION
- Deploy snapshots via git branches suffixed with `-SNAPSHOT`
    - Once deployed, you can view them at https://oss.sonatype.org/content/repositories/snapshots/com/juul/stropping/
- Push to Sonatype via git tags
    - We can [promote to Maven central](https://youtu.be/dXR4pJ_zS-0?t=239) via https://oss.sonatype.org/#welcome

Library consumers can use the snapshots via:

```groovy
repositories {
    maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
}

dependencies {
    androidTestImplementation "com.juul.stropping:stropping:$version"
}
```